### PR TITLE
test: use same glassfish jersey version

### DIFF
--- a/administration/rest/pom.xml
+++ b/administration/rest/pom.xml
@@ -285,22 +285,21 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
-			<version>2.32</version>
+			<version>${org.glassfish.jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
-			<version>3.1.5</version>
+			<version>${org.glassfish.jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-binding</artifactId>
-			<version>3.1.5</version>
+			<version>${org.glassfish.jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
-
 
 		<dependency>
 			<groupId>com.sun.jersey</groupId>

--- a/information/rest/pom.xml
+++ b/information/rest/pom.xml
@@ -213,19 +213,19 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.core</groupId>
 			<artifactId>jersey-client</artifactId>
-			<version>2.32</version>
+			<version>${org.glassfish.jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
-			<version>3.1.5</version>
+			<version>${org.glassfish.jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-json-binding</artifactId>
-			<version>3.1.5</version>
+			<version>${org.glassfish.jersey.version}</version>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,7 @@
 		<uvms.pom.version>3.24</uvms.pom.version>
 		<uvms.commons.version>4.1.15</uvms.commons.version>
 		<sun.jersey.version>1.19.4</sun.jersey.version>
+		<org.glassfish.jersey.version>2.38</org.glassfish.jersey.version>
 		<usm4uvms.version>4.1.12</usm4uvms.version>
 	</properties>
 


### PR DESCRIPTION
Updated to 2.38. Something broke in 2.39, hence not upgrading to latest.